### PR TITLE
check effect instance for infinite duration

### DIFF
--- a/src/main/java/cofh/nonvflash/mixin/GameRendererMixin.java
+++ b/src/main/java/cofh/nonvflash/mixin/GameRendererMixin.java
@@ -2,6 +2,7 @@ package cofh.nonvflash.mixin;
 
 import cofh.nonvflash.NoNVFlash;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +25,7 @@ public abstract class GameRendererMixin {
         if (NoNVFlash.fadeOut.get()) {
             if (living.hasEffect(NIGHT_VISION)) {
                 int duration = living.getEffect(NIGHT_VISION).getDuration();
-                i = duration > NoNVFlash.fadeTicks.get() ? NoNVFlash.maxBrightness.get() : duration * NoNVFlash.fadeRate.get();
+                i = (duration == MobEffectInstance.INFINITE_DURATION || duration > NoNVFlash.fadeTicks.get()) ? NoNVFlash.maxBrightness.get() : duration * NoNVFlash.fadeRate.get();
             }
         }
         callback.setReturnValue((float) i);


### PR DESCRIPTION
In at least Minecraft 1.20 effects can last forever by using a duration of -1.


Command to get infinite night vision:
`/effect give @s minecraft:night_vision infinite`

With the current implementation the night vision effect does nothing when used with infinite duration.