### PR TITLE
Add compatibility with Oculus/Iris Shaders

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,67 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "1.18.x" ]
+  pull_request:
+    branches: [ "1.18.x" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+
+    # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+    # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.
+    #
+    # - name: Setup Gradle
+    #   uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    #   with:
+    #     gradle-version: '8.9'
+    #
+    # - name: Build with Gradle 8.9
+    #   run: gradle build
+
+  dependency-submission:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/src/main/java/cofh/nonvflash/mixin/GameRendererMixin.java
+++ b/src/main/java/cofh/nonvflash/mixin/GameRendererMixin.java
@@ -20,9 +20,10 @@ public abstract class GameRendererMixin {
     )
     private static void onGetNightVisionScale(LivingEntity living, float partialTicks, CallbackInfoReturnable<Float> callback) {
 
-        float i = NoNVFlash.maxBrightness;
-        if (NoNVFlash.fadeOut) {
-            if (living.hasEffect(NIGHT_VISION)) {
+        float i = 0.0f;
+        if (living.hasEffect(NIGHT_VISION)) {
+            i = NoNVFlash.maxBrightness;
+            if (NoNVFlash.fadeOut) {
                 int duration = living.getEffect(NIGHT_VISION).getDuration();
                 i = duration > NoNVFlash.fadeTicks ? NoNVFlash.maxBrightness : duration * NoNVFlash.fadeRate;
             }


### PR DESCRIPTION
Returns a zero when an entity has no night vision instead of max brightness.

This fixes shaders that rely on getting the night vision from a player for lighting effect, as you can call onGetNightVisionScale on any entity regardless of whether it has night vision or not if you use Oculus/Iris. 

(See https://github.com/Asek3/Oculus/blob/a2ed79988284940bf3f72e1321f6c36530ccbf97/src/main/java/net/coderbot/iris/uniforms/CommonUniforms.java#L253)